### PR TITLE
Vagrant : run provision.sh unprivileged

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.synced_folder '.', '/vagrant', type: 'nfs', mount_options: ['nolock', 'actimeo=1', 'fsc']
 
     # Provisioning
-    config.vm.provision "shell", path: "vagrant/provision.sh"
+    if File.exists?(ENV['HOME'] + "/.gitconfig")
+        config.vm.provision "file", source: "~/.gitconfig", destination: "/home/vagrant/.gitconfig"
+    end
+    config.vm.provision "shell", path: "vagrant/provision.sh", keep_color: true, privileged: false
 end
 
 local_vagrantfile = File.expand_path('../Vagrantfile.local', __FILE__)

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -4,10 +4,10 @@
 [ -f /etc/php/7.0/mods-available/geoip.ini ] && sudo rm /etc/php/7.0/mods-available/geoip.ini || true
 
 # Configuration spécifique d'Apache
-a2enmod ssl
-a2dissite 000-default.conf
-cp /vagrant/vagrant/apache.conf /etc/apache2/sites-available/apache.conf
-a2ensite apache.conf
-service apache2 restart
+sudo a2enmod ssl
+sudo a2dissite 000-default.conf
+sudo cp /vagrant/vagrant/apache.conf /etc/apache2/sites-available/apache.conf
+sudo a2ensite apache.conf
+sudo service apache2 restart
 
 cd /vagrant && make install


### PR DESCRIPTION
Also copy the host's ~/.gitconfig if it exists


Pour tester (ping @sergemazille quand tu auras un peu de temps) : `rm -rf vendor && make dev-from-scratch && vagrant ssh -c "git config user.name"`

Le composer install devrait marcher maintenant (l'agent forwarding était bien activé, mais ca ne suit pas quand on passe en root).