### PR TITLE
fix deprecated 

### DIFF
--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -8,7 +8,6 @@
 namespace AppBundle\Twig;
 
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Wizaplace\Basket\Basket;
 use Wizaplace\Basket\BasketService;
@@ -20,11 +19,11 @@ use Wizaplace\User\UserService;
 
 class AppExtension extends \Twig_Extension
 {
-    /** @var  CatalogService */
+    /** @var CatalogService */
     private $catalogService;
-    /** @var  Session */
+    /** @var SessionInterface */
     private $session;
-    /** @var  UserService */
+    /** @var UserService */
     private $userService;
     /** @var BasketService */
     private $basketService;


### PR DESCRIPTION
Since Symfony 3.3, we should hints classes instead of types