### PR TITLE
Setup instructions without Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This method can be used when Vagrant cannot be made to work.
 Requirements:
 
 - PHP 7.1
+- Composer
 - NPM
 - Gulp
 


### PR DESCRIPTION
Quand Vagrant ne marche pas, `bin/console server:run` peut très bien faire l'affaire sur le poste d'un développeur à jour.