### PR TITLE
Fix shipping groups in the basket summary

### DIFF
--- a/app/Resources/views/checkout/basket-summary.html.twig
+++ b/app/Resources/views/checkout/basket-summary.html.twig
@@ -3,13 +3,15 @@
 
     {# products #}
     <ul>
-        {% for company in basket.companyGroups %}
-            {% for item in company.shippingGroups.0.items %}
-                <li>
-                    <span class="title">{{item.productName}}</span><br />
-                    <span class="title text-grey">{{item.quantity}}x</span>
-                    <span class="title">{{item.individualPrice|price}}&nbsp;{{ 'including_taxes'|trans }}</span> 
-                </li>
+        {% for companyGroup in basket.companyGroups %}
+            {% for shippingGroup in companyGroup.shippingGroups %}
+                {% for item in shippingGroup.items %}
+                    <li>
+                        <span class="title">{{item.productName}}</span><br />
+                        <span class="title text-grey">{{item.quantity}}x</span>
+                        <span class="title">{{item.individualPrice|price}}&nbsp;{{ 'including_taxes'|trans }}</span>
+                    </li>
+                {% endfor %}
             {% endfor %}
         {% endfor %}
     </ul>


### PR DESCRIPTION
Dans le récap de commande on ignorait les cas avec multiples shipping groups.

avant : 

![capture d ecran 2017-08-18 a 11 10 19](https://user-images.githubusercontent.com/720328/29452267-fddf3c64-8405-11e7-87c8-6f4d912223cf.png)

après : 

![capture d ecran 2017-08-18 a 11 10 06](https://user-images.githubusercontent.com/720328/29452271-ff836162-8405-11e7-8f50-cdf776f02a20.png)
