### PR TITLE
Fixed declinations page

### DIFF
--- a/src/AppBundle/Controller/ProductController.php
+++ b/src/AppBundle/Controller/ProductController.php
@@ -68,8 +68,10 @@ class ProductController extends Controller
                 'id' => $option->getId(),
                 'name' => $option->getName(),
                 'variants' => array_map(function (OptionVariant $variant) use ($product, $option, $variantIdByOptionId) {
-                    $isSelected = $variantIdByOptionId[$option->getId()] === $variant->getId();
-
+                    $isSelected = false;
+                    if (isset($variantIdByOptionId[$option->getId()])) {
+                        $isSelected = $variantIdByOptionId[$option->getId()] === $variant->getId();
+                    }
                     $variantIdByOptionId[$option->getId()] = $variant->getId();
                     $declinationId = $product->getDeclinationFromOptions($variantIdByOptionId)->getId();
 


### PR DESCRIPTION
#### Problème:

La page d'une déclinaison d'un produit plantait `Undefined offset X`.

#### Solution:

Check l'existence de la clé `$option->getId()` dans l'array `variantIdByOptionId` avant de comparer les ids