### PR TITLE
Don't log 404s in production.

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -19,6 +19,8 @@ monolog:
         logstash:
             type:         fingers_crossed
             handler:      logstash_file
+            excluded_404s:
+                - ^/
         logstash_file:
             type:         stream
             level:        'warning'


### PR DESCRIPTION
We already have those in the access logs.