### PR TITLE
Allow overriding api.base_url from env var

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -10,6 +10,8 @@ parameters:
     slug.regexp: !php/const:Wizaplace\SDK\Seo\SeoService::SLUG_REGEXP
     recaptcha.key: '%env(RECAPTCHA_KEY)%'
     recaptcha.secret: '%env(RECAPTCHA_SECRET)%'
+    api.base_url: '%env(API_BASE_URL)%'
+    # default values
     env(RECAPTCHA_KEY): '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
     env(RECAPTCHA_SECRET): '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
 

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -2,13 +2,13 @@ imports:
     - { resource: config.yml }
 
 parameters:
-    api.base_url: 'https://sandbox.wizaplace.com/api/v1/'
     googlemaps.api_key: 'AIzaSyC6pzFn22J8wZ9OMuYBButVwUKvmo5Jx1w' #@TODO: change me
     wizaplace.system_user_password: '%env(WIZAPLACE_SYSTEM_USER_PASSWORD)%'
     api.connect_timeout: '%env(API_CONNECT_TIMEOUT)%'
     api.read_timeout: '%env(API_READ_TIMEOUT)%'
     api.timeout: '%env(API_TIMEOUT)%'
     # default env values
+    env(API_BASE_URL): 'https://sandbox.wizaplace.com/api/v1/'
     env(API_CONNECT_TIMEOUT): 30
     env(API_READ_TIMEOUT): 30
     env(API_TIMEOUT): 30

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -4,7 +4,7 @@
 parameters:
     # A secret key that's used to generate certain security-related tokens
     secret: ThisTokenIsNotSoSecretChangeIt
-    api.base_url: 'https://sandbox.wizaplace.com/api/v1/'
+    env(API_BASE_URL): 'http://wizaplace.loc/api/v1/'
     wizaplace.system_user_password: 'FakeSecret'
     api.connect_timeout: 30
     api.read_timeout: 30

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -4,7 +4,7 @@
 parameters:
     # A secret key that's used to generate certain security-related tokens
     secret: ThisTokenIsNotSoSecretChangeIt
-    env(API_BASE_URL): 'http://wizaplace.loc/api/v1/'
+    env(API_BASE_URL): 'https://sandbox.wizaplace.com/api/v1/'
     wizaplace.system_user_password: 'FakeSecret'
     api.connect_timeout: 30
     api.read_timeout: 30


### PR DESCRIPTION
Ca laisse des valeurs saines par défaut, mais ca permet un override via l'env quand on en a besoin (pour les staging envs par example).

Si c'est accepté je répliquerai sur certains projets.