### PR TITLE
Bring back star-rating library

### DIFF
--- a/src/AppBundle/Resources/public/scripts/includes/ui.js
+++ b/src/AppBundle/Resources/public/scripts/includes/ui.js
@@ -1,0 +1,14 @@
+const ui = {
+
+    // init star rating lib
+    renderRatings: function() {
+        $('.js-rating').rating({
+            min: 0,
+            max: 5,
+            step: 1,
+            size: 'sm',
+            showClear: false,
+            showCaption: false
+        });
+    },
+};

--- a/src/AppBundle/Resources/public/scripts/main.js
+++ b/src/AppBundle/Resources/public/scripts/main.js
@@ -7,6 +7,9 @@ $(function() {
     // Replace exceeding text with ellipsis (three dots)
     $('.ellipsis').dotdotdot();
 
+    // init star rating lib
+    ui.renderRatings();
+
     // init slick behaviour
     slick.init();
 


### PR DESCRIPTION
fix #238

La bibliothèque avait été indûment "nettoyée"

# Avant :
![avant](https://user-images.githubusercontent.com/7364168/35674607-76086cde-0745-11e8-90fe-a652eeab0f5e.png)


# Après :
![apres](https://user-images.githubusercontent.com/7364168/35674614-7bb01a1a-0745-11e8-9fe4-a1e12fff12fd.png)

