### PR TITLE
Update reviews route

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -295,12 +295,12 @@ cms_page:
 
 # reviews
 create_product_review:
-    path: /product/add_review
+    path: /product/add/review
     defaults: { _controller: AppBundle:Product:review }
     methods: [POST]
 
 create_company_review:
-    path: /company/add_review
+    path: /company/add/review
     defaults: { _controller: AppBundle:Company:review }
     methods: [POST]
 


### PR DESCRIPTION
La route `/product/add_review` n'était jamais atteinte, toujours catchée par `/product/{productId}` du wizaplace/front-bundle

La route `company/add_review` a aussi été mise à jour pour garder de la cohérence