### PR TITLE
Added title and description meta tags on product and search pages

### DIFF
--- a/src/AppBundle/Resources/translations/messages.fr.json
+++ b/src/AppBundle/Resources/translations/messages.fr.json
@@ -490,5 +490,17 @@
             "message": "Message",
             "submit": "Envoyer"
         }
+    },
+
+    "seo": {
+        "search_page_title": "%query%",
+        "search_page_title_default": "Page recherche",
+        "search_page_description": "Page recherche",
+        "product_page_title": "%productName%",
+        "product_page_description": "%productDescription%",
+        "company_page_title": "%companyName%",
+        "company_page_description": "%companyDescription%",
+        "attribute_page_title": "%variantName%",
+        "attribute_page_description": "%variantDescription%"
     }
 }

--- a/src/AppBundle/Resources/views/attribute/variant-attribute.html.twig
+++ b/src/AppBundle/Resources/views/attribute/variant-attribute.html.twig
@@ -1,5 +1,11 @@
 {% extends '@App/search/search.html.twig' %}
 
+{% block title -%}{{ 'seo.attribute_page_title'|trans({'%variantName%': selectedVariant.name|default})|striptags }}{%- endblock %}
+
+{% block meta_description -%}
+    <meta name="description" content="{{ 'seo.attribute_page_description'|trans({ '%variantDescription%': selectedVariant.description|default('seo.attribute_page_title'|trans({ '%variantName%': selectedVariant.name|default })) })|striptags }}">
+{%- endblock %}
+
 {% block searchHeader %}
     <h1>{{ selectedVariant.name }}</h1>
     <img src="{{ selectedVariant.image|imageUrl }}">

--- a/src/AppBundle/Resources/views/company/company.html.twig
+++ b/src/AppBundle/Resources/views/company/company.html.twig
@@ -1,5 +1,11 @@
 {% extends '@App/search/search.html.twig' %}
 
+{% block title -%}{{ 'seo.company_page_title'|trans({'%companyName%': company.name|default})|striptags }}{%- endblock %}
+
+{% block meta_description -%}
+    <meta name="description" content="{{ 'seo.company_page_description'|trans({ '%companyDescription%': company.description|default('seo.company_page_title'|trans({ '%companyName%': company.name|default })) })|striptags }}">
+{%- endblock %}
+
 {% block searchHeader %}
     <h1>{{ company.name }}</h1>
     <p>{{ company.description }}</p>

--- a/src/AppBundle/Resources/views/product/product.html.twig
+++ b/src/AppBundle/Resources/views/product/product.html.twig
@@ -1,5 +1,12 @@
 {% extends '@App/layout.html.twig' %}
 
+{% block title -%}{{ 'seo.product_page_title'|trans({'%productName%': product.name|default})|striptags }}{%- endblock %}
+
+{% block meta_description -%}
+    {# product description (default to product name) #}
+    <meta name="description" content="{{ 'seo.product_page_description'|trans({ '%productDescription%': product.description|default('seo.product_page_title'|trans({ '%productName%': product.name|default })) })|striptags }}">
+{%- endblock %}
+
 {% block meta %}
     <link rel="canonical" href="{{ product|productUrl }}">
 {% endblock %}

--- a/src/AppBundle/Resources/views/search/search.html.twig
+++ b/src/AppBundle/Resources/views/search/search.html.twig
@@ -1,5 +1,13 @@
 {% extends '@App/layout.html.twig' %}
 
+{% block title -%}
+    {{ 'seo.search_page_title'|trans({ '%query%': searchQuery|default('seo.search_page_title_default'|trans) }) }}
+{%- endblock %}
+
+{% block meta_description -%}
+    <meta name="description" content="{{ 'seo.search_page_description'|trans }}">
+{%- endblock %}
+
 {% block body %}
     <div id="search-page" v-cloak>
 


### PR DESCRIPTION
Ajout des titres et balises <meta> description aux pages produit, recherche, recherche de type catégorie et recherche de type attributs

![meta](https://user-images.githubusercontent.com/7364168/36108616-8b47c67c-101d-11e8-9239-c01d683297c9.png)
