### PR TITLE
remove orders routes

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -248,27 +248,6 @@ basket_update_comments:
     defaults: { _controller: AppBundle:Basket:updateComments }
     methods: [POST]
 
-# orders
-order_all:
-    path: /commandes
-    defaults: { _controller: AppBundle:Order:viewOrders }
-    methods: [GET]
-
-order:
-    path: /commande/{orderId}
-    defaults: { _controller: AppBundle:Order:viewOrder }
-    methods: [GET]
-
-create_return:
-    path: /commande/{orderId}/retour
-    defaults: { _controller: AppBundle:Order:createReturn }
-    methods: [POST]
-
-create_return_form:
-    path: /commande/{orderId}/retour
-    defaults: { _controller: AppBundle:Order:displayCreateReturn }
-    methods: [GET]
-
 category:
     path: /c/{slug}
     defaults: { _controller: AppBundle:Category:view }

--- a/src/AppBundle/Resources/views/profile/create-return.html.twig
+++ b/src/AppBundle/Resources/views/profile/create-return.html.twig
@@ -2,7 +2,7 @@
 
 {% block profile_content %}
     Réaliser un retour : <br/>
-    <form method="post" action="{{ path('create_return', {'orderId' : order.id}) }}">
+    <form method="post" action="{{ path('profile_create_return') }}">
         <input type="hidden" name="orderId" value="{{ order.id }}">
         <input type="text" name="comments" placeholder="commentaires">
         {% for item in order.orderItem %}

--- a/src/AppBundle/Resources/views/profile/returns.html.twig
+++ b/src/AppBundle/Resources/views/profile/returns.html.twig
@@ -18,7 +18,7 @@
             <tbody>
             {% for order in orders|default %}
                 <tr>
-                    <td><a href="{{ path('order', {'orderId': order.id}) }}" class="text-blue">{{ order.id }}</a></td>
+                    <td><a href="{{ path('profile_order', {'orderId': order.id}) }}" class="text-blue">{{ order.id }}</a></td>
                     <td>{{ order.timestamp.format('d-m-y') }}</td>
                     <td>{{ order.shippingName }}</td>
                     <td>{{ 'order_table.body.total' | trans({'%price%': order.total|price }) }}</td>
@@ -53,7 +53,7 @@
             <tbody>
             {% for return in returns|default %}
                 <tr>
-                    <td><a href="{{ path('order', {'orderId': return.id}) }}" class="text-blue">{{ return.id }}</a></td>
+                    <td><a href="{{ path('profile_order', {'orderId': return.id}) }}" class="text-blue">{{ return.id }}</a></td>
                     <td>{{ return.createdAt.format('d-m-y') }}</td>
                     <td>
                         <ul>


### PR DESCRIPTION
Les routes orders ne sont plus utilisées (et n'ont pas de controller).  
Correction apportée aussi dans les templates qui utilisait ces routes.

fix #277 