### PR TITLE
Fix: horizontal scroll on large screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,8 @@ The application should be available at http://localhost:8000/
 
 To compile assets, simply run `gulp`. Gulp will watch changes and recompile Javascript, CSS, etc. automatically.
 
+### Integration
+
 Here are our integration guidelines: [wizaplace/integration-guidelines](https://github.com/wizaplace/integration-guidelines).
+
+A minimal stylesheet (`src/AppBundle/Resources/public/style/wizaplace/demo.scss`) is provided for demo purpose but must be removed before starting the integration phase as it can cause style conflicts with your own styles.

--- a/src/AppBundle/Resources/public/style/wizaplace/demo.scss
+++ b/src/AppBundle/Resources/public/style/wizaplace/demo.scss
@@ -144,3 +144,7 @@ footer {
 .slick-next {
     right: 0 !important;
 }
+
+form.searchbar {
+    flex-wrap: wrap;
+}

--- a/src/AppBundle/Resources/public/style/wizaplace/demo.scss
+++ b/src/AppBundle/Resources/public/style/wizaplace/demo.scss
@@ -139,3 +139,8 @@ footer {
         display: block;
     }
 }
+
+// misc
+.slick-next {
+    right: 0 !important;
+}


### PR DESCRIPTION
fix #268
J'ai rajouté deux règles dans demo.scss
En soit le scroll horizontal n'est pas grave car il ne serait pas visible sur un projet intégré.
J'en ai profité pour ajouter une remarque dans le readme pour indiquer à l'intégrateur que ce même fichier demo.scss doit être supprimé au moment de l'intégration.