### PR TITLE
Fix inscription vendeur

### DIFF
--- a/src/AppBundle/Controller/AuthController.php
+++ b/src/AppBundle/Controller/AuthController.php
@@ -159,11 +159,11 @@ class AuthController extends BaseController
 
             $idCard = $uploadedFiles['admin_document_id_card'];
             $kbis = $uploadedFiles['company_document_kbis'];
-            $bic = $uploadedFiles['company_document_bic']; // RIB
+            $rib = $uploadedFiles['company_document_rib']; // RIB
 
             if (! $email || ! $firstName || ! $lastName || ! $name || ! $password || ! $phoneNumber ||
                 ! $legalStatus || ! $zipcode || ! $capital || ! $siret || ! $rcs || ! $city || ! $country ||
-                ! $address || ! $idCard || ! $kbis || ! $bic || ! $capital || ! $terms) {
+                ! $address || ! $idCard || ! $kbis || ! $rib || ! $capital || ! $terms) {
                 $notification = $this->translator->trans('fields_required_error_message');
                 $this->addFlash('danger', $notification);
 
@@ -195,7 +195,11 @@ class AuthController extends BaseController
                 $registration->setDescription($description);
                 $registration->addUploadedFile('kbis', $kbis);
                 $registration->addUploadedFile('idCard', $idCard);
-                $registration->addUploadedFile('bic', $bic);
+                $registration->addUploadedFile('rib', $rib);
+                $registration->setUrl($url);
+                $registration->setVatNumber($vat);
+                $registration->setCapital($capital);
+                $registration->setRcs($rcs);
 
                 $companyService->register($registration);
 

--- a/src/AppBundle/Resources/translations/messages.fr.json
+++ b/src/AppBundle/Resources/translations/messages.fr.json
@@ -118,7 +118,7 @@
     "company_documents_max_size" : "L'ensemble des fichiers ne doit pas dépasser : 20MB",
     "admin_document_id_card": "Pièce d'identité (carte d'identité ou passeport)",
     "company_document_kbis": "Extrait Kbis (récépissé INSEE pour les autoentrepreneurs)",
-    "company_document_bic": "RIB",
+    "company_document_rib": "RIB",
     "admin_no_vat_checkbox": "Je déclare bénéficier du régime d'auto-entrepreneur ou être déclaré auto-entrepreneur et ne pas posséder de n° de TVA intra communautaire.",
     "terms_of_service": "Conditions générales d'utilisation",
     "terms_of_service_url": "#",

--- a/src/AppBundle/Resources/views/auth/vendor-registration.html.twig
+++ b/src/AppBundle/Resources/views/auth/vendor-registration.html.twig
@@ -96,8 +96,8 @@
                 <label for="company-document-kbis" class="required">{{ 'company_document_kbis'|trans }}</label>
                 <input id="company-document-kbis" name="company_document_kbis" type="file" required>
 
-                <label for="company-document-bic" class="required">{{ 'company_document_bic'|trans }}</label>
-                <input id="company-document-bic" name="company_document_bic" type="file" required>
+                <label for="company-document-rib" class="required">{{ 'company_document_rib'|trans }}</label>
+                <input id="company-document-rib" name="company_document_rib" type="file" required>
             </fieldset>
 
             {# terms of service and terms of sales #}

--- a/src/AppBundle/Resources/views/common/header/_pop_account.html.twig
+++ b/src/AppBundle/Resources/views/common/header/_pop_account.html.twig
@@ -1,4 +1,5 @@
 {# user account links #}
+{{ dump(app.user.isVendor) }}
 <li><a href="{{ path('profile') }}">{{ 'header.account.menu.profile'|trans }}</a></li>
 <li><a href="{{ path('profile_orders') }}">{{ 'header.account.menu.orders'|trans }}</a></li>
 <li><a href="{{ path('profile_discussions') }}">{{ 'header.account.menu.discussion'|trans }}</a></li>

--- a/src/AppBundle/Resources/views/common/header/_pop_account.html.twig
+++ b/src/AppBundle/Resources/views/common/header/_pop_account.html.twig
@@ -1,5 +1,4 @@
 {# user account links #}
-{{ dump(app.user.isVendor) }}
 <li><a href="{{ path('profile') }}">{{ 'header.account.menu.profile'|trans }}</a></li>
 <li><a href="{{ path('profile_orders') }}">{{ 'header.account.menu.orders'|trans }}</a></li>
 <li><a href="{{ path('profile_discussions') }}">{{ 'header.account.menu.discussion'|trans }}</a></li>


### PR DESCRIPTION
Fixes #302 

Il manquait certains champs, et le champ `bic` devait être nommé `rib`.
[Lien vers l'API](https://sandbox.wizaplace.com/api/v1/doc/#tag/Companies%2Fpaths%2F~1companies~1%7BcompanyId%7D~1files%2Fpost)