### PR TITLE
add real ip to apache logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . /app
 RUN composer dump-autoload --optimize --classmap-authoritative --no-dev --no-interaction
 
 # Production image
-FROM php:7.2-apache as app
+FROM php:7.2.7-apache as app
 LABEL maintainer="dev@wizaplace.com"
 RUN apt-get update && apt-get install -y \
     libicu-dev \
@@ -32,8 +32,13 @@ COPY --from=vendors /app/vendor/ /var/www/html/vendor
 # Copie des assets générés dans l'image temporaire node
 COPY --from=assets /app/web/ /var/www/html/web
 
-RUN a2enmod rewrite headers \
+RUN a2enmod rewrite headers remoteip \
     && sed -i 's@/var/www/html@/var/www/html/web@' /etc/apache2/sites-available/000-default.conf
+
+RUN { \
+        echo 'RemoteIPHeader X-Forwarded-For'; \
+        echo 'LogFormat "%a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined'; \
+    } >> "$APACHE_CONFDIR/conf-available/docker-php.conf"
 
 ENV SYMFONY_ENV "prod"
 


### PR DESCRIPTION
- On trust le header `X-Forwarded-For` de toutes les sources car on est dans un environnement _safe_ ([remoteip](https://httpd.apache.org/docs/2.4/fr/mod/mod_remoteip.html#remoteipheader))
- On override le format des logs de apache pour afficher la _remote_ip_ ([logs](https://httpd.apache.org/docs/2.4/fr/mod/mod_log_config.html#formats))